### PR TITLE
Use zlib module from runtime

### DIFF
--- a/au.edu.uq.esys.escript.json
+++ b/au.edu.uq.esys.escript.json
@@ -93,17 +93,6 @@
             ]
         },
         {
-            "name": "zlib",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/madler/zlib.git",
-                    "tag": "v1.3.1",
-                    "commit": "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf"
-                }
-            ]
-        },
-        {
             "name": "hdf5",
             "buildsystem": "cmake-ninja",
             "config-opts": [


### PR DESCRIPTION
Freedesktop runtime version 24.08 appears to provide the **zlib** module. 

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

**Related manifest file** 

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/24.08/elements/bootstrap/zlib.bst 

Fixes: https://github.com/flathub/au.edu.uq.esys.escript/issues/36